### PR TITLE
quit out of the calculator with cmd-q plus activate on launch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,17 @@ mod styles;
 use gpui::*;
 use root::*;
 
+actions!(calculator, [Quit]);
+
 fn main() {
     App::new().run(|cx: &mut AppContext| {
+        cx.activate(true);
+        cx.on_action(|_: &Quit, cx| cx.quit());
+        cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
+        cx.set_menus(vec![Menu {
+            name: "Calculator",
+            items: vec![MenuItem::action("Quit", Quit)],
+        }]);
         let bounds = Bounds::centered(None, size(px(300.0), px(300.0)), cx);
 
         cx.open_window(


### PR DESCRIPTION

I always find it handy with [gpui](https://www.gpui.rs/) applications to have the ability to do two things with your app.

- cmd-q out of your app with the keyboard instead of using your mouse to quit
- and to show the window immediately upon launch

```rust
cx.activate(true);
```

